### PR TITLE
Allow all API endpoint downloads to be asynchronous

### DIFF
--- a/lib/util/data_sync/media_sync.dart
+++ b/lib/util/data_sync/media_sync.dart
@@ -82,7 +82,7 @@ class MediaSync {
   /// Iterates through the download queue and downloads each file asynchronously,
   /// adding database records and saving to disk as files are received.
   /// Performs a free-storage check prior to downloading.
-  Future<void> processDownloadQueue({bool asyncDownload}) async {
+  Future<void> processDownloadQueue() async {
     upTo = 0; // file that we are up to downloading
     outOf = _downloadQueue.length; // out of how many
     totalSize = _downloadQueue.fold<int>(0, (v, n) => v + n.size);
@@ -105,7 +105,7 @@ class MediaSync {
     while (_downloadQueue.isNotEmpty) {
       MediaData mediaData = _downloadQueue.removeFirst();
 
-      if (asyncDownload) {
+      if (Env.asyncDownload) {
         futures.add(downloadMediaFile(mediaData).catchError((ex, stacktrace) {
           print(ex);
           print(stacktrace);

--- a/lib/util/data_sync/sync_manager.dart
+++ b/lib/util/data_sync/sync_manager.dart
@@ -141,7 +141,7 @@ class SyncManager {
       // ----------------------------------------------------------------
 
       // Process the download queue for media files ---------------------
-      await mediaSync.processDownloadQueue(asyncDownload: Env.asyncDownload);
+      await mediaSync.processDownloadQueue();
       _updateProgress(SyncState.DataDownload, 80);
       // ----------------------------------------------------------------
 


### PR DESCRIPTION
Drastically improves update speed when many fact files / quizzes / activities need to be downloaded.

Updates occasionally fail, but application seems to work on a second attempt. Unsure as to reason why.