### PR TITLE
Improve download size indication

### DIFF
--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:discover_deep_cove/util/screen.dart';
+import 'package:flutter/material.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -133,21 +135,27 @@ class Env {
   }
 
   /// API endpoint to return summary of all required media files.
-  static String mediaListUrl(CmsServerLocation server) {
-    return _getCmsUrl(server) + _mediaUrl;
+  static String mediaListUrl(CmsServerLocation server, BuildContext context) {
+    return _getCmsUrl(server) +
+        _mediaUrl +
+        '?width=${Screen.isTablet(context) ? 500 : null}';
   }
 
   /// API endpoint to return details of a single media file.
-  static String mediaDetailsUrl(CmsServerLocation server, int id) {
-    return _getCmsUrl(server) + _mediaUrl + '/$id';
+  static String mediaDetailsUrl(
+      CmsServerLocation server, int id, BuildContext context) {
+    return _getCmsUrl(server) +
+        _mediaUrl +
+        '/$id' +
+        '?width=${Screen.isTablet(context) ? 500 : null}';
   }
 
   /// API endpoint to return the specified media file.
-  static String mediaDownloadUrl(CmsServerLocation server, String filename,
-      {int width = 0}) {
+  static String mediaDownloadUrl(
+      CmsServerLocation server, String filename, BuildContext context) {
     return _getCmsUrl(server) +
         _mediaDownloadUrl +
-        '?filename=$filename&width=$width';
+        '?filename=$filename&width=${Screen.isTablet(context) ? 500 : null}';
   }
 
   /// API endpoint to return a summary of active quizzes.

--- a/lib/util/data_sync/media_sync.dart
+++ b/lib/util/data_sync/media_sync.dart
@@ -61,7 +61,7 @@ class MediaSync {
 
     // Retrieve list of required media files from server, as MediaData objects
     String jsonString =
-        await NetworkUtil.requestDataString(Env.mediaListUrl(server));
+        await NetworkUtil.requestDataString(Env.mediaListUrl(server, context));
     List<dynamic> jsonData = json.decode(jsonString);
     List<MediaData> remoteMedia =
         jsonData.map((i) => MediaData.fromJson(i)).toList();
@@ -132,16 +132,15 @@ class MediaSync {
   Future<void> downloadMediaFile(MediaData mediaData) async {
     // Retrieve mediaFile object from server, and deserialize
     String jsonString = await NetworkUtil.requestDataString(
-        Env.mediaDetailsUrl(server, mediaData.id));
+        Env.mediaDetailsUrl(server, mediaData.id, context));
     MediaFile mediaFile = mediaFileBeanMain.fromMap(json.decode(jsonString));
 
     // Download file from server, to memory. Download larger images if device
     // is a tablet.
     String absPath = Env.getResourcePath(mediaFile.category);
     String filename = mediaData.filename;
-    Http.Response response = await Http.get(Env.mediaDownloadUrl(
-        server, filename,
-        width: Screen.isTablet(context) ? 500 : null));
+    Http.Response response =
+        await Http.get(Env.mediaDownloadUrl(server, filename, context));
 
     // Assign path to mediaFile object
     mediaFile.path = join(mediaFile.category, mediaData.filename);
@@ -215,7 +214,7 @@ class MediaSync {
     for (MediaFile mediaFile in _updateQueue) {
       // Request the meta data for the media file
       String jsonString = await NetworkUtil.requestDataString(
-          Env.mediaDetailsUrl(server, mediaFile.id));
+          Env.mediaDetailsUrl(server, mediaFile.id, context));
 
       // Update the database using the deserialized, updated, media file
       await mediaFileBeanTemp.update(

--- a/lib/util/network_util.dart
+++ b/lib/util/network_util.dart
@@ -25,7 +25,10 @@ class NetworkUtil {
   /// a GET request to the supplied address.
   static Future<bool> _returnsResponse(String address) async {
     try {
+      print('Attempting to contact remote server at $address');
       Http.Response response = await Http.get(address);
+      print('Response:');
+      print(response.statusCode);
       return response.statusCode == 200;
     } catch (ex) {
       // no DNS resolution, invalid url, etc


### PR DESCRIPTION
Mobile app will receive more accurate information regarding the sizes of the images that it is downloaded, rather than the original size.

Note: These changes will not have any effect until the corresponding updates are made to the server API. Also note that many files on the server were not uploaded through the site, and have their file sizes recorded as 0. This will not be a problem on the production server.