### PR TITLE
Activity improvements

### DIFF
--- a/lib/util/screen.dart
+++ b/lib/util/screen.dart
@@ -8,13 +8,15 @@ class Screen {
   static double height(BuildContext context, {double percentage = 100}) =>
       MediaQuery.of(context).size.height / 100 * percentage;
 
-  static setOrientations(BuildContext context) => Screen.isTablet(context)
-      ? SystemChrome.setPreferredOrientations([
-          DeviceOrientation.portraitUp,
-          DeviceOrientation.landscapeLeft,
-          DeviceOrientation.landscapeRight
-        ])
-      : SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+  static setOrientations(BuildContext context, {bool forcePortrait = false}) =>
+      (Screen.isTablet(context) && !forcePortrait)
+          ? SystemChrome.setPreferredOrientations([
+              DeviceOrientation.portraitUp,
+              DeviceOrientation.landscapeLeft,
+              DeviceOrientation.landscapeRight
+            ])
+          : SystemChrome.setPreferredOrientations(
+              [DeviceOrientation.portraitUp]);
 
   static bool isPortrait(BuildContext context) =>
       MediaQuery.of(context).orientation == Orientation.portrait;

--- a/lib/views/activites/activity_unlock.dart
+++ b/lib/views/activites/activity_unlock.dart
@@ -2,6 +2,7 @@ import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
 import 'package:discover_deep_cove/widgets/misc/text/heading.dart';
+import 'package:discover_deep_cove/widgets/misc/text/sub_heading.dart';
 import 'package:flutter/material.dart';
 
 class ActivityUnlock extends StatefulWidget {
@@ -42,143 +43,112 @@ class _ActivityUnlockState extends State<ActivityUnlock> {
 
   buildContent(BuildContext context) {
     return (Screen.isTablet(context) && !Screen.isPortrait(context))
-        ? GridView.count(
-            crossAxisCount: 2,
-            children: [
-              getBottomHalf(context),
-              getTopHalf(context),
+        ? SingleChildScrollView(
+            child: Row(
+            children: <Widget>[
+              Expanded(child: Column(children: buildQRExample(),)),
+              Expanded(child: buildInputs())
             ],
-          )
+          ))
         : SingleChildScrollView(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                getTopHalf(context),
-                getBottomHalf(context),
+                buildInputs(),
+                SizedBox(height: 30),
+                ...buildQRExample(),
               ],
             ),
           );
   }
 
-  getTopHalf(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.isTablet(context) ? 28.0 : 8.0,
-            vertical: Screen.width(context,
-                percentage: Screen.isPortrait(context) ? 15 : 5),
-          ),
-          child: Container(
-            width: Screen.width(context,
-                percentage: Screen.width(context) < 600 ? 100 : 80),
-            color: Theme.of(context).primaryColor,
-            child: Column(
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(
-                    top: Screen.width(context, percentage: 5),
-                    bottom: Screen.width(context, percentage: 5),
-                  ),
-                  child: Heading(
-                    "Enter QR unlock code:",
-                    size: Screen.width(context) >= 600
-                        ? 30
-                        : Screen.width(context) <= 350 ? 16 : 20,
-                  ),
-                ),
-                Transform.scale(
-                  scale: Screen.isTablet(context) ? 1.25 : 1,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(10.0),
-                    child: Container(
-                      width: Screen.width(
-                        context,
-                        percentage: Screen.isTablet(context) ? 30 : 62.5,
-                      ),
-                      color: Colors.white,
-                      child: TextField(
-                        focusNode: _textFieldFocus,
-                        controller: textController,
-                        keyboardType: TextInputType.phone,
-                        style: TextStyle(color: Colors.black),
-                        decoration: InputDecoration(
-                          hintText: 'Enter code...',
-                          border: InputBorder.none,
-                          contentPadding: EdgeInsets.all(8.0),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: EdgeInsets.symmetric(
-                    vertical: Screen.width(context, percentage: 5),
-                  ),
-                  child: OutlineButton(
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Heading(
-                        "Unlock",
-                        size: Screen.width(context) >= 600
-                            ? 30
-                            : Screen.width(context) <= 350 ? 16 : 20,
-                      ),
-                    ),
-                    onPressed: () => verifyCode(context),
-                    borderSide: BorderSide(
-                      color: Color(0xFFFFFFFF),
-                    ),
-                  ),
-                ),
-              ],
+  buildInputs() {
+    return Container(
+      width: 1500, // will not overflow
+      height: Screen.isLandscape(context)
+          ? Screen.height(context) - 50
+          : Screen.height(context) * 0.4,
+      color: Theme.of(context).primaryColor,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.only(
+              top: Screen.width(context, percentage: 5),
+              bottom: Screen.width(context, percentage: 5),
+            ),
+            child: Heading(
+              "Enter QR unlock code:",
+              size: Screen.width(context) >= 600
+                  ? 30
+                  : Screen.width(context) <= 350 ? 16 : 20,
             ),
           ),
-        ),
-      ],
+          Transform.scale(
+            scale: Screen.isTablet(context) ? 1.25 : 1,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(10.0),
+              child: Container(
+                width: Screen.width(
+                  context,
+                  percentage: Screen.isLandscape(context) ? 30 : 60,
+                ),
+                color: Colors.white,
+                child: TextField(
+                  focusNode: _textFieldFocus,
+                  controller: textController,
+                  keyboardType: TextInputType.phone,
+                  style: TextStyle(color: Colors.black, fontSize: 20),
+                  decoration: InputDecoration(
+                    hintText: 'Enter code...',
+                    border: InputBorder.none,
+                    contentPadding: EdgeInsets.all(8.0),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(
+              vertical: Screen.width(context, percentage: 5),
+            ),
+            child: OutlineButton(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Heading(
+                  "Unlock",
+                  size: Screen.width(context) >= 600
+                      ? 30
+                      : Screen.width(context) <= 350 ? 16 : 20,
+                ),
+              ),
+              onPressed: () => verifyCode(context),
+              borderSide: BorderSide(
+                color: Color(0xFFFFFFFF),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
-  getBottomHalf(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Column(
-          children: <Widget>[
-            Padding(
-              padding: EdgeInsets.symmetric(
-                  horizontal: Screen.width(context) <= 350 ? 20 : 50),
-              child: BodyText(
-                "Example QR code.",
-                size: Screen.width(context) > 600 ? 30 : null,
-              ),
-            ),
-            Padding(
-              padding: EdgeInsets.symmetric(
-                  vertical: Screen.height(context, percentage: 2),
-                  horizontal: Screen.width(context) <= 350 ? 20 : 50),
-              child: Container(
-                width: Screen.width(context,
-                    percentage: Screen.width(context) <= 350
-                        ? 50
-                        : !Screen.isPortrait(context) ? 40 : 60),
-                height: Screen.width(context,
-                    percentage: Screen.width(context) <= 350
-                        ? 50
-                        : !Screen.isPortrait(context) ? 40 : 60),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(5),
-                  image: DecorationImage(
-                    image: AssetImage('assets/invalidQRcode.png'),
-                    fit: BoxFit.contain,
-                  ),
-                ),
-              ),
-            ),
-          ],
+  buildQRExample() {
+    return <Widget>[
+      Container(
+        height: Screen.isLandscape(context)
+            ? Screen.height(context, percentage: 60)
+            : Screen.width(context, percentage: 60),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5),
+          image: DecorationImage(
+            image: AssetImage('assets/invalidQRcode.png'),
+            fit: BoxFit.contain,
+          ),
         ),
-      ],
-    );
+      ),
+      SizedBox(height: 25),
+      SubHeading('Example QR Code')
+    ];
   }
 }

--- a/lib/views/activites/count_activity_view.dart
+++ b/lib/views/activites/count_activity_view.dart
@@ -1,9 +1,15 @@
+import 'dart:io';
+
 import 'package:discover_deep_cove/data/models/activity/activity.dart';
+import 'package:discover_deep_cove/env.dart';
 import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_app_bar.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_pass_save_bar.dart';
+import 'package:discover_deep_cove/widgets/activities/editAnswer.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
+import 'package:discover_deep_cove/widgets/misc/text/sub_heading.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
@@ -34,7 +40,7 @@ class _CountActivityViewState extends State<CountActivityView> {
         ),
         body: buildContent(),
         bottomNavigationBar: widget.isReview
-            ? BottomBackButton(isReview: widget.isReview)
+            ? BottomBackButton()
             : ActivityPassSaveBar(
                 onTapSave: () => saveAnswer(),
               ),
@@ -42,159 +48,185 @@ class _CountActivityViewState extends State<CountActivityView> {
   }
 
   buildContent() {
-    return (Screen.isTablet(context) && Screen.isLandscape(context))
-        ? GridView.count(
-            crossAxisCount: 2,
+    return Screen.isLandscape(context)
+        ? Row(
             children: [
-              getTopHalf(),
-              getBottomHalf(),
+              Expanded(child: getTopHalf()),
+              CustomVerticalDivider(),
+              Expanded(child: getBottomHalf())
             ],
           )
-        : Column(
-            children: [
-              getTopHalf(),
-              Flexible(
-                child: getBottomHalf(),
+        : Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  getTopHalf(),
+                  getBottomHalf(),
+                ],
               ),
-            ],
+            ),
           );
   }
 
   getTopHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 2.5),
-            vertical: Screen.height(context, percentage: 5.0),
-          ),
-          child: BodyText(
-            widget.activity.description,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            buildGraphic(),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: 20,
+                vertical: 15,
+              ),
+              child: BodyText(
+                widget.activity.description,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 25 : null,
+              ),
+            ),
+            Screen.isPortrait(context)
+                ? Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 15,
+                    ),
+                    child: Divider(
+                      height: 40,
+                      color: Color(0xFF777777),
+                    ),
+                  )
+                : Container(),
+          ],
         ),
-        SizedBox(
-          height: Screen.height(
-            context,
-            percentage: 5.0,
-          ),
-        ),
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 2.5),
-            vertical: Screen.height(context, percentage: 5.0),
-          ),
-          child: BodyText(
-            widget.activity.task,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
-        ),
-        Screen.isPortrait(context)
-            ? Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: Screen.height(context, percentage: 5.0),
-                ),
-                child: Divider(
-                  color: Color(0xFF777777),
-                ),
-              )
-            : Container(),
-      ],
+      ),
     );
   }
 
   getBottomHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.all(12.0),
-          child: widget.isReview
-              ? BodyText(
-                  "You Counted:",
-                  size: Screen.isTablet(context) ? 30 : null,
-                )
-              : SizedBox(
-                  height: Screen.height(context, percentage: 5.0),
-                ),
-        ),
-        SizedBox(
-          height: Screen.height(
-            context,
-            percentage: Screen.isSmall(context) ? 5.0 : 10.0,
+    return Padding(
+      padding: EdgeInsets.only(bottom: 25),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.only(
+              left: 20,
+              right: 20,
+              bottom: 20,
+            ),
+            child: SubHeading(
+              widget.activity.task,
+            ),
           ),
-        ),
-        widget.isReview
-            ? Container(
-                width: Screen.width(context),
-                height: Screen.height(context,
-                    percentage: Screen.isLandscape(context) ? 15.0 : 10.0),
-                color: Theme.of(context).primaryColor,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: <Widget>[
-                    Text(
-                      widget.activity.userCount.toString(),
-                      style: TextStyle(
-                        fontSize: Screen.isSmall(context) ? 40 : 60,
-                        color: Colors.white,
+          Padding(
+              padding: EdgeInsets.all(12.0),
+              child: widget.isReview
+                  ? Padding(
+                      padding: EdgeInsets.only(bottom: 20),
+                      child: SubHeading(
+                        "Your answer:",
                       ),
-                    ),
-                  ],
-                ),
-              )
-            : Container(
-                width: Screen.width(context),
-                height: Screen.height(context,
-                    percentage: Screen.isLandscape(context) ? 15.0 : 10.0),
-                color: Theme.of(context).primaryColor,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: <Widget>[
-                    Transform.scale(
-                      scale: Screen.isTablet(context) ? 2 : 1.5,
-                      child: IconButton(
-                        icon: Icon(
-                          FontAwesomeIcons.chevronLeft,
+                    )
+                  : Container()),
+          widget.isReview
+              ? Container(
+                  width: Screen.width(context,
+                      percentage: Screen.isLandscape(context) ? 30 : 65),
+                  height: Screen.width(context,
+                      percentage: Screen.isLandscape(context) ? 15 : 35),
+                  decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(15)),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: <Widget>[
+                      Text(
+                        widget.activity.userCount.toString(),
+                        style: TextStyle(
+                          fontSize: Screen.isSmall(context) ? 60 : 80,
                           color: Colors.white,
                         ),
-                        onPressed: () {
-                          if (count > 1) {
-                            setState(() {
-                              count = count - 1;
-                            });
-                          }
-                        },
-                        color: Colors.white,
                       ),
-                    ),
-                    BodyText(
-                      count.toString(),
-                      size: Screen.isSmall(context)
-                          ? 40
-                          : Screen.isTablet(context) ? 70 : 50,
-                    ),
-                    Transform.scale(
-                      scale: Screen.isTablet(context) ? 2 : 1.5,
-                      child: IconButton(
-                        icon: Icon(
-                          FontAwesomeIcons.chevronRight,
+                    ],
+                  ),
+                )
+              : Container(
+                  width: Screen.width(context,
+                      percentage: Screen.isLandscape(context) ? 30 : 65),
+                  height: Screen.width(context,
+                      percentage: Screen.isLandscape(context) ? 15 : 35),
+                  decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(15)),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: <Widget>[
+                      Transform.scale(
+                        scale: Screen.isTablet(context) ? 2 : 1.5,
+                        child: IconButton(
+                          icon: Icon(
+                            FontAwesomeIcons.chevronLeft,
+                            color: Colors.white,
+                          ),
+                          onPressed: () {
+                            if (count > 0) {
+                              setState(() {
+                                count = count - 1;
+                              });
+                            }
+                          },
                           color: Colors.white,
                         ),
-                        onPressed: () {
-                          if (count < 100) {
-                            setState(() {
-                              count = count + 1;
-                            });
-                          }
-                        },
                       ),
-                    ),
-                  ],
+                      BodyText(
+                        count.toString(),
+                        size: Screen.isSmall(context) ? 60 : 80,
+                      ),
+                      Transform.scale(
+                        scale: Screen.isTablet(context) ? 2 : 1.5,
+                        child: IconButton(
+                          icon: Icon(
+                            FontAwesomeIcons.chevronRight,
+                            color: Colors.white,
+                          ),
+                          onPressed: () {
+                            if (count < 100) {
+                              setState(() {
+                                count = count + 1;
+                              });
+                            }
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-      ],
+          SizedBox(height: 25),
+          widget.isReview ? EditAnswer() : Container()
+        ],
+      ),
+    );
+  }
+
+  buildGraphic() {
+    return Padding(
+      padding:
+          EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
+      child: widget.activity.image == null
+          ? null
+          : Container(
+              width: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 30 : 85),
+              height: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 30 : 85),
+              decoration: BoxDecoration(
+                  image: DecorationImage(
+                fit: BoxFit.cover,
+                image: FileImage(
+                    File(Env.getResourcePath(widget.activity.image.path))),
+              )),
+              child: Container()),
     );
   }
 

--- a/lib/views/activites/photograph_activity_view.dart
+++ b/lib/views/activites/photograph_activity_view.dart
@@ -146,18 +146,19 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
                 padding: EdgeInsets.only(
                   bottom: 6,
                 ),
-                child: CustomFab(
-                  icon: FontAwesomeIcons.camera,
-                  text: _image == null ? "I see it!" : "Try again",
-                  onPressed: () {
-                    _onImageButtonPressed(context);
-                  },
-                ),
+                child: FloatingActionButton(
+              onPressed: () {
+                _onImageButtonPressed(context);
+              },
+              child: const Icon( FontAwesomeIcons.camera),
+            ),
               ),
             ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
     );
   }
+
+  
 
   buildGraphic() {
     return Padding(

--- a/lib/views/activites/photograph_activity_view.dart
+++ b/lib/views/activites/photograph_activity_view.dart
@@ -10,9 +10,12 @@ import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/util/util.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_app_bar.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_pass_save_bar.dart';
+import 'package:discover_deep_cove/widgets/activities/editAnswer.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
 import 'package:discover_deep_cove/widgets/misc/custom_fab.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
+import 'package:discover_deep_cove/widgets/misc/text/sub_heading.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:gallery_saver/gallery_saver.dart';
@@ -74,6 +77,8 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
       decoration: BoxDecoration(border: Border.all(color: Colors.white30)),
       width: Screen.width(context,
           percentage: Screen.isPortrait(context) ? 90 : 45),
+      height: Screen.width(context,
+          percentage: Screen.isPortrait(context) ? 90 : 45),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -91,7 +96,7 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
     );
   }
 
-  Widget _getCenterChild() {
+  Widget _buildImageSection() {
     return FutureBuilder(
         future: widget.isReview ? _getSavedPhoto() : _getPreview(),
         builder: (context, snapshot) {
@@ -125,26 +130,7 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
             ? () => displayFactFile(widget.activity.factFileId)
             : null,
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(40, 20, 40, 20),
-            child: BodyText(widget.activity.description),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(40, 0, 40, 20),
-            child: BodyText(widget.activity.task),
-          ),
-          Expanded(
-            child: Center(
-              child: Padding(
-                padding: EdgeInsets.all(8),
-                child: _getCenterChild(),
-              ),
-            ),
-          )
-        ],
-      ),
+      body: buildContent(),
       bottomNavigationBar: widget.isReview
           ? BottomBackButton()
           : ActivityPassSaveBar(
@@ -158,7 +144,7 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
               alignment: Alignment.bottomCenter,
               child: Padding(
                 padding: EdgeInsets.only(
-                  bottom: 8,
+                  bottom: 6,
                 ),
                 child: CustomFab(
                   icon: FontAwesomeIcons.camera,
@@ -173,71 +159,114 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
     );
   }
 
-  buildContent() {
-    return Center(
-      child: (Screen.isTablet(context) && Screen.isLandscape(context))
-          ? GridView.count(
-              crossAxisCount: 2,
-              children: [
-                getTopHalf(),
-                getBottomHalf(),
-              ],
-            )
-          : Column(
-              children: [
-                getTopHalf(),
-                Flexible(
-                  child: getBottomHalf(),
-                ),
-              ],
-            ),
+  buildGraphic() {
+    return Padding(
+      padding:
+          EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
+      child: widget.activity.image == null
+          ? null
+          : Container(
+              width: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 35 : 85),
+              height: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 35 : 85),
+              decoration: BoxDecoration(
+                  image: DecorationImage(
+                    fit: BoxFit.cover,
+                image: FileImage(
+                    File(Env.getResourcePath(widget.activity.image.path))),
+              )),
+              child: Container()),
     );
+  }
+
+  buildContent() {
+    return (Screen.isTablet(context) && Screen.isLandscape(context))
+        ? Row(
+            children: [
+              Expanded(child: getTopHalf()),
+              CustomVerticalDivider(),
+              Expanded(child: getBottomHalfLandscape())
+            ],
+          )
+        : Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [getTopHalf(), getBottomHalfPortrait()],
+              ),
+            ),
+          );
   }
 
   getTopHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Padding(
-          padding: EdgeInsets.fromLTRB(
-            Screen.width(context, percentage: 5),
-            Screen.height(context, percentage: 2.5),
-            Screen.width(context, percentage: 5),
-            Screen.height(context, percentage: 2.5),
-          ),
-          child: BodyText(
-            widget.activity.description,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            buildGraphic(),
+            Padding(
+              padding: EdgeInsets.all(20),
+              child: BodyText(
+                widget.activity.description,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 30 : null,
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.all(20),
+              child: SubHeading(
+                widget.activity.task,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 30 : null,
+              ),
+            ),
+          ],
         ),
-        Padding(
-          padding: EdgeInsets.fromLTRB(
-            Screen.width(context, percentage: 5),
-            0,
-            Screen.width(context, percentage: 5),
-            Screen.height(context, percentage: 2.5),
-          ),
-          child: BodyText(
-            widget.activity.task,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
-        ),
-      ],
+      ),
     );
   }
 
-  getBottomHalf() {
+  getBottomHalfLandscape() {
     return Column(
       children: <Widget>[
         Expanded(
           child: Center(
-            child: Padding(
-              padding: EdgeInsets.all(8),
-              child: _getCenterChild(),
+            child: Container(
+              margin: EdgeInsets.fromLTRB(8, 24, 8, 8),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: _buildImageSection(),
+                    ),
+                    widget.isReview ? EditAnswer() : Container()
+                  ],
+                ),
+              ),
             ),
           ),
         ),
       ],
+    );
+  }
+
+  getBottomHalfPortrait() {
+    return Center(
+      child: Container(
+        margin: EdgeInsets.fromLTRB(8, 24, 8, 8),
+        child: Column(
+          children: <Widget>[
+            BodyText('Your answer:'),
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: 12),
+              child: _buildImageSection(),
+            ),
+            widget.isReview ? EditAnswer() : Container()
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/views/activites/photograph_activity_view.dart
+++ b/lib/views/activites/photograph_activity_view.dart
@@ -171,11 +171,15 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
               height: Screen.width(context,
                   percentage: Screen.isLandscape(context) ? 35 : 85),
               decoration: BoxDecoration(
-                  image: DecorationImage(
-                    fit: BoxFit.cover,
-                image: FileImage(
-                    File(Env.getResourcePath(widget.activity.image.path))),
-              )),
+                image: DecorationImage(
+                  fit: BoxFit.cover,
+                  image: FileImage(
+                    File(
+                      Env.getResourcePath(widget.activity.image.path),
+                    ),
+                  ),
+                ),
+              ),
               child: Container()),
     );
   }

--- a/lib/views/activites/photograph_activity_view.dart
+++ b/lib/views/activites/photograph_activity_view.dart
@@ -261,7 +261,7 @@ class _PhotographActivityViewState extends State<PhotographActivityView> {
       );
 
       if (await Util.savePhotosToGallery(context))
-        GallerySaver.saveImage(_image.path);
+        await GallerySaver.saveImage(_image.path);
 
       // Save the image to the users photos directory, and delete temp image
       ImageHandler.saveImage(

--- a/lib/views/activites/picture_select_activity_view.dart
+++ b/lib/views/activites/picture_select_activity_view.dart
@@ -130,12 +130,6 @@ class _PictureSelectActivityViewState extends State<PictureSelectActivityView> {
                       size: Screen.isTablet(context) ? 30 : null,
                     )
                   : Container(),
-              BodyText(
-                !widget.isReview
-                    ? widget.activity.imageOptions[photoIndex].name
-                    : widget.activity.selectedPicture.name,
-                size: Screen.isTablet(context) ? 30 : null,
-              ),
             ],
           ),
         ),

--- a/lib/views/activites/picture_select_activity_view.dart
+++ b/lib/views/activites/picture_select_activity_view.dart
@@ -5,10 +5,13 @@ import 'package:discover_deep_cove/env.dart';
 import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_app_bar.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_pass_save_bar.dart';
+import 'package:discover_deep_cove/widgets/activities/editAnswer.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/image_source.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
 import 'package:discover_deep_cove/widgets/activities/selected_photo.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
+import 'package:discover_deep_cove/widgets/misc/text/sub_heading.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
@@ -51,7 +54,7 @@ class _PictureSelectActivityViewState extends State<PictureSelectActivityView> {
       ),
       body: buildContent(),
       bottomNavigationBar: widget.isReview
-          ? BottomBackButton(isReview: widget.isReview)
+          ? BottomBackButton()
           : ActivityPassSaveBar(onTapSave: () => saveAnswer()),
       backgroundColor: Theme.of(context).backgroundColor,
     );
@@ -59,262 +62,305 @@ class _PictureSelectActivityViewState extends State<PictureSelectActivityView> {
 
   buildContent() {
     return (Screen.isTablet(context) && Screen.isLandscape(context))
-        ? GridView.count(
-            crossAxisCount: 2,
-            children: [
-              getTopHalf(),
-              getBottomHalf(),
+        ? Row(
+            children: <Widget>[
+              Expanded(child: getTopHalf()),
+              CustomVerticalDivider(),
+              Expanded(child: getBottomHalf())
             ],
           )
-        : Column(
-            children: [
-              getTopHalf(),
-              getBottomHalf(),
-            ],
+        : Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  getTopHalf(),
+                  getBottomHalf(),
+                ],
+              ),
+            ),
           );
   }
 
   getTopHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 5),
-            vertical: Screen.height(context, percentage: 1.25),
-          ),
-          child: BodyText(
-            widget.activity.description,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            buildGraphic(),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: 25,
+                vertical: 15,
+              ),
+              child: BodyText(
+                widget.activity.description + widget.activity.description,
+                // Todo
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 25 : null,
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: 25,
+                vertical: 15,
+              ),
+              child: BodyText(
+                widget.activity.task,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 30 : null,
+              ),
+            ),
+            Screen.isPortrait(context)
+                ? Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: Screen.width(context, percentage: 5),
+                      vertical: Screen.height(context, percentage: 1.25),
+                    ),
+                    child: Divider(
+                      color: Color(0xFFFFFFFF),
+                    ),
+                  )
+                : Container(),
+          ],
         ),
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 5),
-            vertical: Screen.height(context, percentage: 1.25),
-          ),
-          child: BodyText(
-            widget.activity.task,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
-        ),
-        Screen.isPortrait(context)
-            ? Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: Screen.width(context, percentage: 5),
-                  vertical: Screen.height(context, percentage: 1.25),
-                ),
-                child: Divider(
-                  color: Color(0xFFFFFFFF),
-                ),
-              )
-            : Container(),
-      ],
+      ),
     );
   }
 
   getBottomHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.height(context, percentage: 5),
-            vertical: Screen.height(context, percentage: 1.25),
-          ),
-          child: Column(
-            children: <Widget>[
-              widget.isReview
-                  ? BodyText(
-                      "You Answered:",
-                      size: Screen.isTablet(context) ? 30 : null,
-                    )
-                  : Container(),
-            ],
-          ),
-        ),
-        !widget.isReview
-            ? Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: Screen.height(context, percentage: 5),
+                vertical: Screen.height(context, percentage: 1.25),
+              ),
+              child: Column(
                 children: <Widget>[
-                  IconButton(
-                    icon: Icon(
-                      FontAwesomeIcons.chevronLeft,
-                      color: Colors.white,
-                      size: Screen.isTablet(context)
-                          ? Screen.height(context, percentage: 5)
-                          : Screen.height(context, percentage: 2.5),
-                    ),
-                    onPressed: previousImage,
-                  ),
-                  Column(
-                    children: <Widget>[
-                      Stack(
-                        children: <Widget>[
-                          Column(
-                            children: <Widget>[
-                              Stack(
-                                alignment: AlignmentDirectional.bottomEnd,
-                                children: <Widget>[
-                                  Container(
-                                    height: Screen.width(
-                                      context,
-                                      percentage: Screen.isTablet(context) &&
-                                              Screen.isLandscape(context)
-                                          ? 35
-                                          : Screen.isTablet(context)
-                                              ? 70
-                                              : Screen.isSmall(context)
-                                                  ? 55
-                                                  : 65,
-                                    ),
-                                    width: Screen.width(
-                                      context,
-                                      percentage: Screen.isTablet(context) &&
-                                              Screen.isLandscape(context)
-                                          ? 35
-                                          : Screen.isTablet(context)
-                                              ? 70
-                                              : Screen.isSmall(context)
-                                                  ? 55
-                                                  : 65,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      borderRadius: BorderRadius.circular(10),
-                                      image: DecorationImage(
-                                        image: FileImage(
-                                          File(
-                                            Env.getResourcePath(widget.activity
-                                                .imageOptions[photoIndex].path),
-                                          ),
-                                        ),
-                                        fit: BoxFit.cover,
-                                      ),
-                                    ),
-                                  ),
-                                  widget.activity.imageOptions[photoIndex]
-                                              .source !=
-                                          null
-                                      ? Container(
-                                          color: Color.fromRGBO(0, 0, 0, 0.75),
-                                          width: Screen.width(
-                                            context,
-                                            percentage: Screen.isTablet(
-                                                        context) &&
-                                                    Screen.isLandscape(context)
-                                                ? 35
-                                                : Screen.isTablet(context)
-                                                    ? 70
-                                                    : Screen.isSmall(context)
-                                                        ? 55
-                                                        : 65,
-                                          ),
-                                          child: Padding(
-                                            padding: const EdgeInsets.all(2.0),
-                                            child: ImageSource(
-                                              isCopyright: widget
-                                                  .activity
-                                                  .imageOptions[photoIndex]
-                                                  .showCopyright,
-                                              source: widget
-                                                  .activity
-                                                  .imageOptions[photoIndex]
-                                                  .source,
-                                            ),
-                                          ),
-                                        )
-                                      : Container(),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Container(
-                          child: SelectedPhoto(
-                            numberOfDots: widget.activity.imageOptions.length,
-                            photoIndex: photoIndex,
-                            context: context,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      FontAwesomeIcons.chevronRight,
-                      color: Colors.white,
-                      size: Screen.isTablet(context)
-                          ? Screen.height(context, percentage: 5)
-                          : Screen.height(context, percentage: 2.5),
-                    ),
-                    onPressed: nextImage,
-                  ),
-                ],
-              )
-            : Stack(
-                alignment: AlignmentDirectional.bottomEnd,
-                children: <Widget>[
-                  Column(
-                    children: <Widget>[
-                      Container(
-                        height: Screen.width(context,
-                            percentage: Screen.isTablet(context) &&
-                                    Screen.isLandscape(context)
-                                ? 35
-                                : Screen.isTablet(context)
-                                    ? 70
-                                    : Screen.isSmall(context) ? 55 : 65),
-                        width: Screen.width(context,
-                            percentage: Screen.isTablet(context) &&
-                                    Screen.isLandscape(context)
-                                ? 35
-                                : Screen.isTablet(context)
-                                    ? 70
-                                    : Screen.isSmall(context) ? 55 : 65),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          image: DecorationImage(
-                            image: FileImage(
-                              File(
-                                Env.getResourcePath(
-                                    widget.activity.selectedPicture.path),
-                              ),
-                            ),
-                            fit: BoxFit.cover,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  widget.activity.imageOptions[photoIndex].source != null
-                      ? Container(
-                          color: Color.fromRGBO(0, 0, 0, 0.75),
-                          width: Screen.width(
-                            context,
-                            percentage: Screen.isTablet(context) &&
-                                    Screen.isLandscape(context)
-                                ? 35
-                                : Screen.isTablet(context)
-                                    ? 70
-                                    : Screen.isSmall(context) ? 55 : 65,
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.all(2.0),
-                            child: ImageSource(
-                              isCopyright: widget.activity
-                                  .imageOptions[photoIndex].showCopyright,
-                              source: widget
-                                  .activity.imageOptions[photoIndex].source,
-                            ),
-                          ),
+                  widget.isReview
+                      ? SubHeading(
+                          "You Answered:",
                         )
                       : Container(),
                 ],
               ),
-      ],
+            ),
+            !widget.isReview
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: <Widget>[
+                      IconButton(
+                        icon: Icon(
+                          FontAwesomeIcons.chevronLeft,
+                          color: Colors.white,
+                          size: Screen.isTablet(context)
+                              ? Screen.height(context, percentage: 5)
+                              : Screen.height(context, percentage: 2.5),
+                        ),
+                        onPressed: previousImage,
+                      ),
+                      Column(
+                        children: <Widget>[
+                          Stack(
+                            children: <Widget>[
+                              Column(
+                                children: <Widget>[
+                                  Stack(
+                                    alignment: AlignmentDirectional.bottomEnd,
+                                    children: <Widget>[
+                                      Container(
+                                        height: Screen.width(
+                                          context,
+                                          percentage: Screen.isTablet(
+                                                      context) &&
+                                                  Screen.isLandscape(context)
+                                              ? 35
+                                              : Screen.isTablet(context)
+                                                  ? 70
+                                                  : Screen.isSmall(context)
+                                                      ? 55
+                                                      : 65,
+                                        ),
+                                        width: Screen.width(
+                                          context,
+                                          percentage: Screen.isTablet(
+                                                      context) &&
+                                                  Screen.isLandscape(context)
+                                              ? 35
+                                              : Screen.isTablet(context)
+                                                  ? 70
+                                                  : Screen.isSmall(context)
+                                                      ? 55
+                                                      : 65,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          borderRadius:
+                                              BorderRadius.circular(10),
+                                          image: DecorationImage(
+                                            image: FileImage(
+                                              File(
+                                                Env.getResourcePath(widget
+                                                    .activity
+                                                    .imageOptions[photoIndex]
+                                                    .path),
+                                              ),
+                                            ),
+                                            fit: BoxFit.cover,
+                                          ),
+                                        ),
+                                      ),
+                                      widget.activity.imageOptions[photoIndex]
+                                                  .source !=
+                                              null
+                                          ? Container(
+                                              color:
+                                                  Color.fromRGBO(0, 0, 0, 0.75),
+                                              width: Screen.width(
+                                                context,
+                                                percentage: Screen.isTablet(
+                                                            context) &&
+                                                        Screen.isLandscape(
+                                                            context)
+                                                    ? 35
+                                                    : Screen.isTablet(context)
+                                                        ? 70
+                                                        : Screen.isSmall(
+                                                                context)
+                                                            ? 55
+                                                            : 65,
+                                              ),
+                                              child: Padding(
+                                                padding:
+                                                    const EdgeInsets.all(2.0),
+                                                child: ImageSource(
+                                                  isCopyright: widget
+                                                      .activity
+                                                      .imageOptions[photoIndex]
+                                                      .showCopyright,
+                                                  source: widget
+                                                      .activity
+                                                      .imageOptions[photoIndex]
+                                                      .source,
+                                                ),
+                                              ),
+                                            )
+                                          : Container(),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Container(
+                              child: SelectedPhoto(
+                                numberOfDots:
+                                    widget.activity.imageOptions.length,
+                                photoIndex: photoIndex,
+                                context: context,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      IconButton(
+                        icon: Icon(
+                          FontAwesomeIcons.chevronRight,
+                          color: Colors.white,
+                          size: Screen.isTablet(context)
+                              ? Screen.height(context, percentage: 5)
+                              : Screen.height(context, percentage: 2.5),
+                        ),
+                        onPressed: nextImage,
+                      ),
+                    ],
+                  )
+                : Stack(
+                    alignment: AlignmentDirectional.center,
+                    children: <Widget>[
+                      Column(
+                        children: <Widget>[
+                          SizedBox(height: 12),
+                          Container(
+                            height: Screen.width(context,
+                                percentage:
+                                    Screen.isLandscape(context) ? 30 : 75),
+                            width: Screen.width(context,
+                                percentage:
+                                    Screen.isLandscape(context) ? 30 : 75),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              image: DecorationImage(
+                                image: FileImage(
+                                  File(
+                                    Env.getResourcePath(
+                                        widget.activity.selectedPicture.path),
+                                  ),
+                                ),
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 12, top: 24),
+                            child: EditAnswer(),
+                          )
+                        ],
+                      ),
+                      widget.activity.imageOptions[photoIndex].source != null
+                          ? Container(
+                              color: Color.fromRGBO(0, 0, 0, 0.75),
+                              width: Screen.width(
+                                context,
+                                percentage: Screen.isTablet(context) &&
+                                        Screen.isLandscape(context)
+                                    ? 35
+                                    : Screen.isTablet(context)
+                                        ? 70
+                                        : Screen.isSmall(context) ? 55 : 65,
+                              ),
+                              child: Padding(
+                                padding: const EdgeInsets.all(2.0),
+                                child: ImageSource(
+                                  isCopyright: widget.activity
+                                      .imageOptions[photoIndex].showCopyright,
+                                  source: widget
+                                      .activity.imageOptions[photoIndex].source,
+                                ),
+                              ),
+                            )
+                          : Container(),
+                    ],
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  buildGraphic() {
+    return Padding(
+      padding:
+          EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
+      child: widget.activity.image == null
+          ? null
+          : Container(
+              width: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 30 : 85),
+              height: Screen.width(context,
+                  percentage: Screen.isLandscape(context) ? 30 : 85),
+              decoration: BoxDecoration(
+                  image: DecorationImage(
+                fit: BoxFit.cover,
+                image: FileImage(
+                    File(Env.getResourcePath(widget.activity.image.path))),
+              )),
+              child: Container()),
     );
   }
 

--- a/lib/views/activites/picture_tap_activity_view.dart
+++ b/lib/views/activites/picture_tap_activity_view.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:discover_deep_cove/data/models/activity/activity.dart';
 import 'package:discover_deep_cove/env.dart';
 import 'package:discover_deep_cove/util/screen.dart';
+import 'package:discover_deep_cove/widgets/activities/editAnswer.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/image_source.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_app_bar.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_pass_save_bar.dart';
@@ -52,7 +54,7 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
       ),
       body: buildContent(),
       bottomNavigationBar: widget.isReview
-          ? BottomBackButton(isReview: widget.isReview)
+          ? BottomBackButton()
           : ActivityPassSaveBar(
               onTapSave: () => saveAnswer(),
             ),
@@ -61,53 +63,56 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
   }
 
   buildContent() {
-    return (Screen.isTablet(context) && Screen.isLandscape(context))
-        ? GridView.count(
-            crossAxisCount: 2,
-            children: [
-              getTopHalf(),
-              getBottomHalf(),
+    return Screen.isLandscape(context)
+        ? Row(
+            children: <Widget>[
+              Expanded(child: getTopHalf()),
+              CustomVerticalDivider(),
+              Expanded(child: getBottomHalf())
             ],
           )
-        : Column(
-            children: [
-              getTopHalf(),
-              Flexible(
-                child: getBottomHalf(),
+        : Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [getTopHalf(), getBottomHalf()],
               ),
-            ],
+            ),
           );
   }
 
   getTopHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 5),
-            vertical: Screen.height(context, percentage: 2.5),
-          ),
-          child: BodyText(
-            widget.activity.description,
-            size: Screen.isTablet(context)
-                ? 25.0
-                : Screen.isSmall(context) ? 14 : 16,
-          ),
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Screen.isPortrait(context)
+                ? SizedBox(height: Screen.height(context, percentage: 4))
+                : Container(),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 30, vertical: 12),
+              child: BodyText(
+                widget.activity.description,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 25.0 : null,
+              ),
+            ),
+            SizedBox(height: Screen.height(context, percentage: 1)),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 30, vertical: 12),
+              child: BodyText(
+                widget.activity.task,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 25.0 : null,
+              ),
+            ),
+            SizedBox(
+                height: Screen.isPortrait(context)
+                    ? Screen.height(context, percentage: 4)
+                    : 0)
+          ],
         ),
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 5),
-            vertical: Screen.height(context, percentage: 1.25),
-          ),
-          child: BodyText(
-            widget.activity.task,
-            size: Screen.isTablet(context)
-                ? 25.0
-                : Screen.isSmall(context) ? 14 : 16,
-          ),
-        ),
-      ],
+      ),
     );
   }
 
@@ -116,14 +121,13 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Container(
-          child: widget.isReview
-              ? BodyText(
-                  "Your Answer:",
-                  size: Screen.isTablet(context)
-                      ? 25.0
-                      : Screen.isSmall(context) ? 14 : 16,
-                )
-              : null,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: widget.isReview
+                ? BodyText("Your Answer",
+                    size: Screen.isTablet(context) ? 25 : 16)
+                : null,
+          ),
         ),
         widget.isReview
             ? Stack(
@@ -131,24 +135,10 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
                 children: <Widget>[
                   Center(
                     child: Container(
-                      height: Screen.width(
-                        context,
-                        percentage: Screen.isTablet(context) &&
-                                Screen.isLandscape(context)
-                            ? 45
-                            : Screen.isTablet(context)
-                                ? 85
-                                : Screen.isSmall(context) ? 75 : 80,
-                      ),
-                      width: Screen.width(
-                        context,
-                        percentage: Screen.isTablet(context) &&
-                                Screen.isLandscape(context)
-                            ? 45
-                            : Screen.isTablet(context)
-                                ? 85
-                                : Screen.isSmall(context) ? 75 : 80,
-                      ),
+                      height: Screen.width(context,
+                          percentage: Screen.isLandscape(context) ? 45 : 85),
+                      width: Screen.width(context,
+                          percentage: Screen.isLandscape(context) ? 45 : 85),
                       child: Container(
                         child: Container(
                           decoration: BoxDecoration(
@@ -219,8 +209,6 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
                       width: _getImageDimension(),
                       child: GestureDetector(
                         onTapDown: _handleTap,
-                        onHorizontalDragUpdate: _handleDrag,
-                        onVerticalDragUpdate: _handleDrag,
                         child: Container(
                           key: _keyImage,
                           child: Container(
@@ -265,8 +253,6 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
                           top: _getYPos(posY),
                           left: _getXPos(posX),
                           child: GestureDetector(
-                            onHorizontalDragUpdate: _handleDrag,
-                            onVerticalDragUpdate: _handleDrag,
                             onTapDown: _handleTap,
                             child: Container(
                               width: Screen.height(context, percentage: 10),
@@ -288,6 +274,10 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
                       : Container(),
                 ],
               ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          child: widget.isReview ? EditAnswer() : Container(),
+        )
       ],
     );
   }
@@ -295,9 +285,8 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
   double _getImageDimension() {
     return Screen.width(
       context,
-      percentage: Screen.isTablet(context) && Screen.isLandscape(context)
-          ? 45
-          : Screen.isTablet(context) ? 85 : Screen.isSmall(context) ? 75 : 80,
+      percentage:
+          Screen.isTablet(context) && Screen.isLandscape(context) ? 40 : 80,
     );
   }
 
@@ -310,10 +299,6 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
               ? -0.5
               : Screen.isSmall(context) ? -2.5 : 0,
     );
-  }
-
-  void _handleDrag(DragUpdateDetails details) {
-    _placeMarker(details.globalPosition);
   }
 
   void _handleTap(TapDownDetails details) {

--- a/lib/views/activites/picture_tap_activity_view.dart
+++ b/lib/views/activites/picture_tap_activity_view.dart
@@ -44,7 +44,15 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
   }
 
   @override
+  void dispose() {
+    // Return default orientations
+    Screen.setOrientations(context);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Force portrait for this view
+    Screen.setOrientations(context, forcePortrait: true);
     return Scaffold(
       appBar: ActivityAppBar(
         text: widget.activity.title,
@@ -52,7 +60,17 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
             ? () => displayFactFile(widget.activity.factFileId)
             : null,
       ),
-      body: buildContent(),
+      body: Screen.isLandscape(context)
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  CircularProgressIndicator(),
+                  BodyText('Loading'),
+                ],
+              ),
+            )
+          : buildContent(),
       bottomNavigationBar: widget.isReview
           ? BottomBackButton()
           : ActivityPassSaveBar(
@@ -285,8 +303,9 @@ class _PictureTapActivityViewState extends State<PictureTapActivityView> {
   double _getImageDimension() {
     return Screen.width(
       context,
-      percentage:
-          Screen.isTablet(context) && Screen.isLandscape(context) ? 40 : 80,
+      percentage: Screen.isTablet(context) && Screen.isLandscape(context)
+          ? 45
+          : Screen.isTablet(context) ? 85 : Screen.isSmall(context) ? 75 : 80,
     );
   }
 

--- a/lib/views/activites/text_answer_activity_view.dart
+++ b/lib/views/activites/text_answer_activity_view.dart
@@ -169,6 +169,7 @@ class _TextAnswerActivityViewState extends State<TextAnswerActivityView> {
                       : ClipRRect(
                     borderRadius: BorderRadius.circular(5),
                     child: Container(
+                      margin: EdgeInsets.only(bottom: 15),
                       width: Screen.width(context, percentage: 87.5),
                       height: Screen.height(context,
                           percentage: Screen.isTablet(context)
@@ -189,7 +190,7 @@ class _TextAnswerActivityViewState extends State<TextAnswerActivityView> {
                       ),
                     ),
                   ),
-                  EditAnswer()
+                  widget.isReview ? EditAnswer() : Container()
                 ],
               ),
             ],
@@ -204,11 +205,7 @@ class _TextAnswerActivityViewState extends State<TextAnswerActivityView> {
       padding:
           EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
       child: widget.activity.image == null
-          ? Icon(
-              FontAwesome.question_circle,
-              size: Screen.isTablet(context) ? 200 : 100,
-              color: Colors.white,
-            )
+          ? null
           : Container(
               width: Screen.width(context, percentage: Screen.isLandscape(context) ? 33 : 85),
               child: Image.file(

--- a/lib/views/activites/text_answer_activity_view.dart
+++ b/lib/views/activites/text_answer_activity_view.dart
@@ -203,14 +203,21 @@ class _TextAnswerActivityViewState extends State<TextAnswerActivityView> {
   buildGraphic() {
     return Padding(
       padding:
-          EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
+      EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
       child: widget.activity.image == null
           ? null
           : Container(
-              width: Screen.width(context, percentage: Screen.isLandscape(context) ? 33 : 85),
-              child: Image.file(
-                  File(Env.getResourcePath(widget.activity.image.path))),
-            ),
+          width: Screen.width(context,
+              percentage: Screen.isLandscape(context) ? 33 : 85),
+          height: Screen.width(context,
+              percentage: Screen.isLandscape(context) ? 33 : 85),
+          decoration: BoxDecoration(
+              image: DecorationImage(
+                fit: BoxFit.cover,
+                image: FileImage(
+                    File(Env.getResourcePath(widget.activity.image.path))),
+              )),
+          child: Container()),
     );
   }
 

--- a/lib/views/activites/text_answer_activity_view.dart
+++ b/lib/views/activites/text_answer_activity_view.dart
@@ -1,10 +1,18 @@
+import 'dart:io';
+
 import 'package:discover_deep_cove/data/models/activity/activity.dart';
+import 'package:discover_deep_cove/env.dart';
 import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_app_bar.dart';
 import 'package:discover_deep_cove/widgets/activities/activity_pass_save_bar.dart';
+import 'package:discover_deep_cove/widgets/activities/editAnswer.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
+import 'package:discover_deep_cove/widgets/misc/text/heading.dart';
+import 'package:discover_deep_cove/widgets/misc/text/sub_heading.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_icons/flutter_icons.dart';
 
 class TextAnswerActivityView extends StatefulWidget {
   final Activity activity;
@@ -32,155 +40,180 @@ class _TextAnswerActivityViewState extends State<TextAnswerActivityView> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-        onTap: () => _textFieldFocus.unfocus(),
-        child: Scaffold(
-          appBar: ActivityAppBar(
-            text: widget.activity.title,
-            onTap: widget.activity.factFileId != null
-                ? () => displayFactFile(widget.activity.factFileId)
-                : null,
-          ),
-          body: Stack(
-            fit: StackFit.expand,
-            children: <Widget>[
-              buildContent(),
-            ],
-          ),
-          bottomNavigationBar: widget.isReview
-              ? BottomBackButton()
-              : ActivityPassSaveBar(onTapSave: () => saveAnswer()),
-          backgroundColor: Theme.of(context).backgroundColor,
-        ));
+      onTap: () => _textFieldFocus.unfocus(),
+      child: Scaffold(
+        appBar: ActivityAppBar(
+          text: widget.activity.title,
+          onTap: widget.activity.factFileId != null
+              ? () => displayFactFile(widget.activity.factFileId)
+              : null,
+        ),
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            buildContent(),
+          ],
+        ),
+        bottomNavigationBar: widget.isReview
+            ? BottomBackButton()
+            : ActivityPassSaveBar(onTapSave: () => saveAnswer()),
+        backgroundColor: Theme.of(context).backgroundColor,
+      ),
+    );
   }
 
   buildContent() {
     return (Screen.isTablet(context) && Screen.isLandscape(context))
-        ? GridView.count(
-            crossAxisCount: 2,
+        ? Row(
             children: [
-              getTopHalf(),
-              getBottomHalf(),
+              Expanded(child: getTopHalf()),
+              CustomVerticalDivider(),
+              Expanded(child: getBottomHalf())
             ],
           )
-        : SingleChildScrollView(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                getTopHalf(),
-                getBottomHalf(),
-              ],
+        : Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  getTopHalf(),
+                  getBottomHalf(),
+                ],
+              ),
             ),
           );
   }
 
   getTopHalf() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 2.5),
-            vertical: Screen.height(context, percentage: 5.0),
-          ),
-          child: BodyText(
-            widget.activity.description,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
+    return Scrollbar(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            buildGraphic(),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: Screen.width(context, percentage: 3),
+                vertical: Screen.height(context, percentage: 2),
+              ),
+              child: BodyText(
+                widget.activity.description,
+                align: TextAlign.left,
+                size: Screen.isTablet(context) ? 30 : null,
+              ),
+            ),
+            Screen.isPortrait(context)
+                ? Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 20,
+                    ),
+                    child: Divider(
+                      color: Color(0xFF777777),
+                    ),
+                  )
+                : Container(),
+          ],
         ),
-        Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Screen.width(context, percentage: 2.5),
-            vertical: Screen.height(context, percentage: 2.5),
-          ),
-          child: BodyText(
-            widget.activity.task,
-            size: Screen.isTablet(context) ? 30 : null,
-          ),
-        ),
-        Screen.isPortrait(context)
-            ? Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: Screen.width(context, percentage: 5),
-                ),
-                child: Divider(
-                  color: Color(0xFF777777),
-                ),
-              )
-            : Container(),
-      ],
+      ),
     );
   }
 
   getBottomHalf() {
     return Padding(
-      padding: EdgeInsets.only(
-        right: Screen.width(context, percentage: 2.5),
+      padding: EdgeInsets.all(
+        20
       ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: widget.isReview
-                ? BodyText(
-                    "You Answered:",
-                    size: Screen.isTablet(context) ? 30 : null,
-                  )
-                : SizedBox(
-                    height: Screen.height(context, percentage: 2.5),
-                  ),
-          ),
-          Column(
+      child: Scrollbar(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
-              widget.isReview
-                  ? Container(
+              Padding(
+                padding: EdgeInsets.symmetric(
+                  vertical: 5,
+                ),
+                child: SubHeading(
+                  widget.activity.task,
+                  size: Screen.isTablet(context) ? 35 : null,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: widget.isReview
+                    ? SubHeading(
+                  "Your answer was",
+                )
+                    : SizedBox(
+                  height: 15,
+                ),
+              ),
+              Column(
+                children: <Widget>[
+                  widget.isReview
+                      ? Container(
+                    margin: EdgeInsets.symmetric(vertical: 15),
+                    width: 1000,
+                    decoration: BoxDecoration(
+                      color: Colors.white30,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                    child: Container(
+                      padding: EdgeInsets.all(20),
+                      child: BodyText(
+                        widget.activity.userText,
+                        align: TextAlign.left,
+                        size: Screen.isTablet(context) ? 30 : null,
+                      ),
+                    ),
+                  )
+                      : ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: Container(
                       width: Screen.width(context, percentage: 87.5),
                       height: Screen.height(context,
                           percentage: Screen.isTablet(context)
                               ? 45.0
                               : Screen.isSmall(context) ? 30.0 : 38.0),
-                      decoration: BoxDecoration(
-                        border: Border.all(
-                            width: 1.0, color: Theme.of(context).primaryColor),
-                        borderRadius: BorderRadius.all(Radius.circular(5.0) //
-                            ),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: BodyText(
-                          widget.activity.userText,
-                          align: TextAlign.left,
-                          size: Screen.isTablet(context) ? 30 : null,
-                        ),
-                      ),
-                    )
-                  : ClipRRect(
-                      borderRadius: BorderRadius.circular(10.0),
-                      child: Container(
-                        width: Screen.width(context, percentage: 87.5),
-                        height: Screen.height(context,
-                            percentage: Screen.isTablet(context)
-                                ? 45.0
-                                : Screen.isSmall(context) ? 30.0 : 38.0),
-                        color: Colors.white,
-                        child: TextField(
-                          focusNode: _textFieldFocus,
-                          keyboardType: TextInputType.multiline,
-                          textCapitalization: TextCapitalization.sentences,
-                          maxLines: 10,
-                          style: TextStyle(color: Colors.black),
-                          controller: controller,
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            contentPadding: EdgeInsets.all(8.0),
-                          ),
+                      color: Colors.white,
+                      child: TextField(
+                        focusNode: _textFieldFocus,
+                        keyboardType: TextInputType.multiline,
+                        textCapitalization: TextCapitalization.sentences,
+                        maxLines: 10,
+                        style: TextStyle(color: Colors.black, fontSize: Screen.isTablet(context) ? 30 : 20),
+                        controller: controller,
+                        decoration: InputDecoration(
+                          border: InputBorder.none,
+                          contentPadding: EdgeInsets.all(8.0),
                         ),
                       ),
                     ),
+                  ),
+                  EditAnswer()
+                ],
+              ),
             ],
           ),
-        ],
+        ),
       ),
+    );
+  }
+
+  buildGraphic() {
+    return Padding(
+      padding:
+          EdgeInsets.symmetric(vertical: Screen.isTablet(context) ? 20 : 10),
+      child: widget.activity.image == null
+          ? Icon(
+              FontAwesome.question_circle,
+              size: Screen.isTablet(context) ? 200 : 100,
+              color: Colors.white,
+            )
+          : Container(
+              width: Screen.width(context, percentage: Screen.isLandscape(context) ? 33 : 85),
+              child: Image.file(
+                  File(Env.getResourcePath(widget.activity.image.path))),
+            ),
     );
   }
 

--- a/lib/views/fact_file/fact_file_details.dart
+++ b/lib/views/fact_file/fact_file_details.dart
@@ -9,6 +9,7 @@ import 'package:discover_deep_cove/env.dart';
 import 'package:discover_deep_cove/util/screen.dart';
 import 'package:discover_deep_cove/widgets/fact_file/nuggets/fact_nugget.dart';
 import 'package:discover_deep_cove/widgets/misc/bottom_back_button.dart';
+import 'package:discover_deep_cove/widgets/misc/custom_vertical_divider.dart';
 import 'package:discover_deep_cove/widgets/misc/image_source.dart';
 import 'package:discover_deep_cove/widgets/misc/text/body_text.dart';
 import 'package:discover_deep_cove/widgets/misc/text/heading.dart';
@@ -113,7 +114,7 @@ class _FactFileDetailsState extends State<FactFileDetails>
             mainAxisSize: MainAxisSize.min,
             children: [
               Expanded(child: getCarousel(tabletView: true), flex: 3),
-              VerticalDivider(thickness: 1, color: Colors.white, width: 15),
+              CustomVerticalDivider(),
               Expanded(
                 flex: 2,
                 child: ListView(

--- a/lib/widgets/activities/activity_app_bar.dart
+++ b/lib/widgets/activities/activity_app_bar.dart
@@ -16,7 +16,7 @@ class ActivityAppBar extends StatelessWidget with PreferredSizeWidget {
       title: SubHeading(
         text,
         size:
-            Screen.isTablet(context) ? 30 : Screen.isSmall(context) ? 16 : null,
+            Screen.isTablet(context) ? 30 : Screen.isSmall(context) ? 16 : 25,
       ),
       actions: <Widget>[
         onTap != null

--- a/lib/widgets/activities/activity_pass_save_bar.dart
+++ b/lib/widgets/activities/activity_pass_save_bar.dart
@@ -26,17 +26,18 @@ class ActivityPassSaveBar extends StatelessWidget {
               ),
               child: OutlineButton(
                 onPressed: this.onTapPass ?? () => Navigator.of(context).pop(),
+                textColor: Colors.white,
+                disabledTextColor: Theme.of(context).primaryColorDark,
+                disabledBorderColor: Theme.of(context).primaryColorDark,
                 borderSide: BorderSide(
                   color: Color(0xFF777777),
                 ),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(5.0),
                 ),
-                child: BodyText(
-                  'Pass',
-                  size: Screen.isTablet(context)
-                      ? 30
-                      : Screen.isSmall(context) ? 14 : 20,
+                child:  Text(
+                  "Pass",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
             ),
@@ -49,17 +50,18 @@ class ActivityPassSaveBar extends StatelessWidget {
               ),
               child: OutlineButton(
                 onPressed: onTapSave,
+                textColor: Colors.white,
+                disabledTextColor: Theme.of(context).primaryColorDark,
+                disabledBorderColor: Theme.of(context).primaryColorDark,
                 borderSide: BorderSide(
                   color: Color(0xFF777777),
                 ),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(5.0),
                 ),
-                child: BodyText(
+                child: Text(
                   "Save",
-                  size: Screen.width(context) >= 600
-                      ? 30
-                      : Screen.width(context) <= 350 ? 16 : 20,
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
             ),

--- a/lib/widgets/misc/custom_vertical_divider.dart
+++ b/lib/widgets/misc/custom_vertical_divider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class CustomVerticalDivider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) =>
+      VerticalDivider(thickness: 1, color: Colors.white, width: 15);
+}

--- a/lib/widgets/misc/text/body_text.dart
+++ b/lib/widgets/misc/text/body_text.dart
@@ -9,7 +9,7 @@ class BodyText extends StatelessWidget {
 
   ///Returns a custom [Text] widget for accessing body1 theme
   ///and has an optional alignment property.
-  BodyText(this.text, {this.align = TextAlign.center, this.size, this.height});
+  BodyText(this.text, {this.align = TextAlign.center, this.size, this.height = 1.5});
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -216,6 +216,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  flutter_icons:
+    dependency: "direct main"
+    description:
+      name: flutter_icons
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0+1"
   flutter_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   toast: ^0.1.4                       # MIT
   image_picker: ^0.6.0+15             # Apache 2.0
   flutter_launcher_icons: ^0.7.2+1    # MIT
+  flutter_icons: 1.0.0+1              # Apache 2.0
   # url_launcher: ^5.1.2                # BSD
   # keyboard_visibility: ^0.5.6         # MIT
   percent_indicator: ^2.1.1+1         # BSD


### PR DESCRIPTION
This PR improves the display of all activity view, especially on tablets in landscape mode. Gridviews have been removed in favour of rows with expanded children. This allows each half to scroll independently if needed.

This PR also adds the ability to display images in the views, which was omitted previously.

The picture tap activity has been forced to portrait mode, due to complication arising with the accuracy of the marker whenever I attempted to resize things.

Please have a good test of all activities (including review screens) before merging and updating the app (on mobile, tablet portrait and tablet landscape).