### PR TITLE
Post trip fixes

### DIFF
--- a/lib/util/verbose_state.dart
+++ b/lib/util/verbose_state.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/cupertino.dart';
+
+abstract class VerboseState<T extends StatefulWidget> extends State<T> {
+  String name;
+
+  VerboseState(){
+    name = this.runtimeType.toString();
+  }
+
+  @override
+  @mustCallSuper
+  Widget build(BuildContext context){
+      print('$name built');
+  }
+
+  @override
+  @mustCallSuper
+  void deactivate() {
+    print('$name deactivated');
+    super.deactivate();
+  }
+
+  @override
+  @mustCallSuper
+  void didUpdateWidget(StatefulWidget oldWidget) {
+    print('$name updated');
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  @mustCallSuper
+  void didChangeDependencies() {
+    print('$name changed dependencies');
+    super.didChangeDependencies();
+  }
+
+  @override
+  @mustCallSuper
+  void dispose() {
+    print('$name disposed');
+    super.dispose();
+  }
+
+  @override
+  @mustCallSuper
+  void reassemble() {
+    print('$name reassembled');
+    super.reassemble();
+  }
+
+  @override
+  @mustCallSuper
+  void initState() {
+    print('$name initialized');
+    super.initState();
+  }
+
+
+}

--- a/lib/views/settings/settings.dart
+++ b/lib/views/settings/settings.dart
@@ -19,11 +19,13 @@ class Settings extends StatefulWidget {
 
 class _SettingsState extends State<Settings> {
   bool savePhotosToGallery;
+  bool resetInProgress;
 
   @override
   void initState() {
-    super.initState();
     _loadConfig();
+    resetInProgress = false;
+    super.initState();
   }
 
   Future<void> _loadConfig() async {
@@ -84,11 +86,13 @@ class _SettingsState extends State<Settings> {
               SettingsButton(
                 iconData: FontAwesomeIcons.qrcode,
                 text: "Manually Enter Code",
-                onTap: () => Navigator.pushNamed(
-                  context,
-                  '/activityUnlock',
-                  arguments: widget.onCodeEntry,
-                ),
+                onTap: () {
+                  Navigator.pushNamed(
+                    context,
+                    '/activityUnlock',
+                    arguments: widget.onCodeEntry,
+                  );
+                },
               ),
               Divider(color: Color(0xFF777777), height: 1),
             ],
@@ -120,7 +124,7 @@ class _SettingsState extends State<Settings> {
               ),
               FlatButton(
                 child: Text('Reset'),
-                onPressed: () => _resetProgress(),
+                onPressed: resetInProgress ? null : () => _resetProgress(),
               ),
             ],
           );
@@ -128,6 +132,9 @@ class _SettingsState extends State<Settings> {
   }
 
   _resetProgress() async {
+    if (resetInProgress) return;
+    resetInProgress = true;
+
     ActivityBean activityBean = ActivityBean.of(context);
     List<Activity> activities = await activityBean.getAll();
     activities.forEach((a) {
@@ -147,6 +154,7 @@ class _SettingsState extends State<Settings> {
     PageStorage.of(context).writeState(context, null, identifier: 'Tracks');
 
     Navigator.of(context).pop();
+    resetInProgress = false;
     Util.showToast(context, 'Progress Reset!');
   }
 }

--- a/lib/views/settings/settings.dart
+++ b/lib/views/settings/settings.dart
@@ -150,7 +150,6 @@ class _SettingsState extends State<Settings> {
     });
 
     PageStorage.of(context).writeState(context, null, identifier: 'Quizzes');
-    PageStorage.of(context).writeState(context, null, identifier: 'FactFiles');
     PageStorage.of(context).writeState(context, null, identifier: 'Tracks');
 
     Navigator.of(context).pop();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -550,6 +550,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.4+6"
   shelf:
     dependency: transitive
     description:
@@ -725,4 +732,4 @@ packages:
     version: "2.1.16"
 sdks:
   dart: ">=2.4.0 <3.0.0"
-  flutter: ">=1.5.9-pre.94 <2.0.0"
+  flutter: ">=1.6.7 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   # keyboard_visibility: ^0.5.6         # MIT
   percent_indicator: ^2.1.1+1         # BSD
   gallery_saver: ^1.0.4               # Apache 2.0
+  shared_preferences: ^0.5.4+6        # BSD
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Prevents double tapping 'Reset' on the reset modal from closing app to black screen.
- Fact files stay in memory after a reset
- Activities automatically unlock regardless of whether they were scanned or manually activated by code.
- Updated the map of the area, added buildings, road areas, and land details.